### PR TITLE
Another bughunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `dotfiles` playbook is imported by `bootstrap`, and is meant to be run on it
 
 ### Reusability
 
-The playbooks themselves are opinionated: I don't rely on external roles so they are heavily personalized and customized to my needs. In theory, they can meet the needs of others, i.e. by forking this repository and modifying the `group_vars` variables and various configs in `files` and `templates` to suit your needs.
+The playbooks are heavily personalized and customized to my needs, but in theory they can meet the needs of others through forking this repository and modifying the `group_vars` variables and various configs in `files` and `templates` to suit your needs.
 
 ## Installing
 

--- a/playbooks/files/dotfiles/.config/tmuxp/home.yml
+++ b/playbooks/files/dotfiles/.config/tmuxp/home.yml
@@ -1,6 +1,6 @@
 ---
 
-session_name: main
+session_name: home
 windows:
   - window_name: Reference
     start_directory: ~/Development/Reference

--- a/playbooks/files/dotfiles/.local/bin/branch
+++ b/playbooks/files/dotfiles/.local/bin/branch
@@ -4,21 +4,21 @@
 # Branches a Git repo as a worktree within tmux.
 # Author: Brad Frank
 # Date: May 2021
-# Tested: GNU bash, version 5.0.18(1)-release (x86_64-apple-darwin19.6.0)
-# Requires: tmux, git
+# Tested: GNU bash, version 5.1.12(1)-release (x86_64-apple-darwin21.1.0)
+# Requires: tmux, git, fzf
 #
 
 projects_dir="$HOME/Development/Projects"
-open_in=window
+open_in="window"
 
 while getopts ':hfr:b:wp' flag; do
-    case "${flag}" in
-        h) echo "Usage: branch [-r <repo>] [-b <branch_name>] [-f <branch_from>] [-w(indow)* | -p(ane) [h*|v]]" ; exit 0 ;;
-        f) branch_from=$OPTARG ;;
-        p) open_in=pane ; split=${OPTARG:-h} ;;
-        r) repo_name=$OPTARG ;;
-        b) new_branch=$OPTARG ;;
-        w) open_in=window ;;
+    case "$flag" in
+        h) echo "Usage: branch [-r <repo>] [-b <branch_name>] [-f <branch_from>] [-w(indow)* | -p(ane)]" ; exit 0 ;;
+        f) branch_from="$OPTARG" ;;
+        p) open_in="pane" ;;
+        r) repo_name="$OPTARG" ;;
+        b) new_branch="$OPTARG" ;;
+        w) open_in="window" ;;
         *) echo "Invalid argument." >&2 ; exit 1 ;;
     esac
 done
@@ -30,18 +30,17 @@ find_dir_fzf() {
 
 [[ -z $repo_name ]] && repo_name="$(find_dir_fzf "$projects_dir")"
 repo_path="$projects_dir/$repo_name"
+
 [[ -z $branch_from ]] && branch_from="$(find_dir_fzf "$repo_path")"
 branch_path="$repo_path/$branch_from"
-cd "$branch_path" || exit 1
+
 [[ -z $new_branch ]] && new_branch="$branch_from-$(date +%F.%T | tr -d ':-')"
-git worktree add "$repo_path/$new_branch"
 repo_branch="$repo_path/$new_branch"
+
+cd "$branch_path" || exit 1
+git worktree add "$repo_branch"
 
 case $open_in in
   window) tmux new-window -n "$repo_name" -c "$repo_branch" ;;
-  pane)   case $split in
-            v) tmux split-window -v -c "$repo_branch" ;;
-            h) tmux split-window -h -c "$repo_branch" ;;
-          esac
-          ;;
+  pane)   tmux split-window -h -c "$repo_branch" ;;
 esac

--- a/playbooks/files/dotfiles/.local/share/zsh/functions/gcsh
+++ b/playbooks/files/dotfiles/.local/share/zsh/functions/gcsh
@@ -1,9 +1,9 @@
 # [gcpkonfig] generate kubectl credentials, usage: gcpkconfig <project1,project2,projectN>
 gcpkonfig() {
-    [[ -z $1 ]] && exit 1
-
     local projects project cluster _project
-    readarray -t -d ',' projects <<< "$1"
+
+    [[ -z $1 ]] && return 1
+    projects=("${(@s/,/)1}")
 
     mv ~/.kube/config ~/.kube/config."$(date --iso-8601=seconds | tr -d ':-')"
 
@@ -14,7 +14,7 @@ gcpkonfig() {
             gcloud --project "$_project" container clusters get-credentials \
                 "$(cut -d, -f2 <<< "$cluster")" --region="$(cut -d, -f1 <<< "$cluster")"
         done <<< "$(gcloud --project "$_project" container clusters list --format="value[separator=','](zone,name)")"
-    done
+    done <<< "$1"
 }
 
 # [gc] alias for gcloud

--- a/playbooks/files/dotfiles/.local/share/zsh/functions/gcsh
+++ b/playbooks/files/dotfiles/.local/share/zsh/functions/gcsh
@@ -14,7 +14,7 @@ gcpkonfig() {
             gcloud --project "$_project" container clusters get-credentials \
                 "$(cut -d, -f2 <<< "$cluster")" --region="$(cut -d, -f1 <<< "$cluster")"
         done <<< "$(gcloud --project "$_project" container clusters list --format="value[separator=','](zone,name)")"
-    done <<< "$1"
+    done
 }
 
 # [gc] alias for gcloud

--- a/playbooks/files/dotfiles/.local/share/zsh/functions/pyenv
+++ b/playbooks/files/dotfiles/.local/share/zsh/functions/pyenv
@@ -1,28 +1,32 @@
 pyenv() {
-  local pyname pyver=3.8 pyfunc
+  local ve version mode
 
   while getopts ':acdhn:v:' flag; do
     case "$flag" in
-      a) pyfunc=activate ;;
-      c) pyfunc=create ;;
+      a) mode=activate ;;
+      c) mode=create ;;
       d) deactivate ; return $? ;;
       h) echo "Usage: pyenv [-a(ctivate) | -c(reate)] [-n <name> -v <version>] | -d(eactivate)" ; return 0 ;;
-      n) pyname=$OPTARG ;;
-      v) pyver=$OPTARG ;;
+      n) ve="$OPTARG" ;;
+      v) version="$OPTARG" ;;
       *) echo "Invalid argument." >&2 ; return 1 ;;
     esac
   done
 
-  case "$pyfunc" in
-    create)   [[ -z $pyname ]] && pyname=ve
-              virtualenv -p "$pyver" "$pyname"
-              ;;
-    activate) [[ -z $pyname ]] && pyname=$(dirname "$(find . -maxdepth 2 -type f -name pyvenv.cfg)")
-              source "$pyname"/bin/activate
-              ;;
-    *)        [[ -z $pyname ]] && pyname=ve
-              virtualenv -p "$pyver" "$pyname"
-              source "$pyname"/bin/activate
-              ;;
+  _create() {
+    [[ -z $ve ]] && ve="ve"
+    [[ -z $version ]] && version=$(python3 --version | grep -Po '3\.\d+')
+    virtualenv -p "$version" "$ve"
+  }
+
+  _activate() {
+    [[ -z $ve ]] && ve="$(dirname "$(find . -maxdepth 2 -type f -name pyvenv.cfg)")"
+    source "$ve/bin/activate"
+  }
+
+  case "$mode" in
+    create)   _create   ;;
+    activate) _activate ;;
+    *)        _create; _activate ;;
   esac
 }

--- a/playbooks/templates/gitconfig.j2
+++ b/playbooks/templates/gitconfig.j2
@@ -15,6 +15,7 @@
   std = stash drop
   stp = stash pop
   stu = stash --include-untracked
+  tags = tag -l --sort=v:refname
   top = rev-parse --show-toplevel
   unstage = reset HEAD --
   upstream = !git branch --show-current | xargs -I{} git branch --set-upstream-to origin/{} {}


### PR DESCRIPTION
This PR finds and squashes various bugs, and smooths out some rough edges:

* tmuxp now uses 'home' instead of 'main' to differentiate from work profile
* Removes horizontal/vertical split option when opening new pane in `branch` script
* Fixes #29
* `pyenv` now uses by default the newest version of Python installed
* Adds a `git tags` alias to list tags in version order
* Clean up wording in README