### PR TITLE
Fix tagging, move Logi Options+

### DIFF
--- a/playbooks/dotfiles.yml
+++ b/playbooks/dotfiles.yml
@@ -40,48 +40,40 @@
         state: directory
         mode: "{{ item['mode'] | default('0755') }}"
       loop: "{{ directories }}"
+      loop_control:
+        label: "{{ item['path'] }}"
       tags: always
 
     - name: Import core dotfiles tasks
       ansible.builtin.import_tasks: tasks/dotfiles/dotfiles.yml
-      tags: dotfiles
 
     - name: Import ssh tasks
       ansible.builtin.import_tasks: tasks/dotfiles/ssh.yml
-      tags: ssh
 
     - name: Import git tasks  # must follow ssh key creation
       ansible.builtin.import_tasks: tasks/dotfiles/git.yml
-      tags: git
 
     - name: Import tmux tasks
       ansible.builtin.import_tasks: tasks/dotfiles/tmux.yml
-      tags: tmux
 
     - name: Import vim tasks
       ansible.builtin.import_tasks: tasks/dotfiles/vim.yml
-      tags: vim
 
     - name: Import k8s tasks
       ansible.builtin.import_tasks: tasks/dotfiles/k8s.yml
-      tags: k8s
 
     - name: Import font tasks
       ansible.builtin.import_tasks: tasks/dotfiles/fonts.yml
-      tags: fonts
 
     - name: Import GitHub tasks
       ansible.builtin.import_tasks: tasks/dotfiles/github.yml
-      tags: github
 
     - name: Import macOS app tasks
       ansible.builtin.import_tasks: tasks/dotfiles/mac_apps.yml
       when: "'Darwin' in ansible_system"
-      tags: [icons, stats]
 
     - name: Import zsh tasks
       ansible.builtin.import_tasks: tasks/dotfiles/zsh.yml
-      tags: [zsh, dotfiles]
 
     - name: Install Python packages
       ansible.builtin.pip:

--- a/playbooks/tasks/bootstrap/packages/os_Darwin.yml
+++ b/playbooks/tasks/bootstrap/packages/os_Darwin.yml
@@ -27,4 +27,5 @@
   ansible.builtin.command: "{{ homebrew_prefix }}/bin/mas install {{ item }}"
   loop: "{{ mas_packages }}"
   when: install_mas_apps
+  changed_when: false
   tags: [packages, mas]

--- a/playbooks/tasks/dotfiles/dotfiles.yml
+++ b/playbooks/tasks/dotfiles/dotfiles.yml
@@ -6,19 +6,23 @@
     compress: false
     owner: false
     group: false
+  tags: dotfiles
 
 - name: Install themes for bat
   ansible.builtin.command: "{{ bat_exec }} cache --build"
   changed_when: false
+  tags: dotfiles
 
 - name: Install glow configs
   ansible.builtin.copy:
     src: apps/glow/
     dest: "{{ glow_config_path }}/"
     mode: 0644
+  tags: dotfiles
 
 - name: Install cheat script
   ansible.builtin.get_url:
     url: https://cht.sh/:cht.sh
     dest: "{{ ansible_user_dir }}/.local/bin/cht"
     mode: 0755
+  tags: dotfiles

--- a/playbooks/tasks/dotfiles/fonts.yml
+++ b/playbooks/tasks/dotfiles/fonts.yml
@@ -7,11 +7,13 @@
     action: latest_release
     token: "{{ github['personal_token'] }}"
   register: nerd_fonts_latest_release
+  tags: fonts
 
 - name: Get latest installed Nerd Fonts version
-  set_fact:
+  ansible.builtin.set_fact:
     nerd_font_version: v0.0.0
   when: nerd_font_version is undefined
+  tags: fonts
 
 - name: Download latest version of Nerd Fonts
   vars:
@@ -23,6 +25,7 @@
     mode: 0644
   when: version != nerd_font_version
   loop: "{{ nerd_fonts }}"
+  tags: fonts
 
 - name: Extract Nerd Fonts
   vars:
@@ -32,12 +35,14 @@
     dest: "{{ font_dir }}/"
   when: version != nerd_font_version
   loop: "{{ nerd_fonts }}"
+  tags: fonts
 
 - name: Find Windows-only fonts
   ansible.builtin.find:
     paths: "{{ font_dir }}"
     patterns: "*Windows Compatible*"
   register: windows_fonts
+  tags: fonts
 
 - name: Delete Windows-only fonts
   ansible.builtin.file:
@@ -46,8 +51,10 @@
   loop: "{{ windows_fonts['files'] }}"
   loop_control:
     label: "{{ item['path'] | basename }}"
+  tags: fonts
 
 - name: Set Nerd Fonts version fact
-  set_fact:
+  ansible.builtin.set_fact:
     nerd_font_version: "{{ nerd_fonts_latest_release['tag'] }}"
     cacheable: true
+  tags: fonts

--- a/playbooks/tasks/dotfiles/git.yml
+++ b/playbooks/tasks/dotfiles/git.yml
@@ -10,6 +10,7 @@
     backup: true
   register: _backup_gitconfig
   notify: Process backups
+  tags: git
 
 - name: Create allowed signers file
   vars:
@@ -18,3 +19,4 @@
     content: "{{ email }} {{ pubkey_content[0] }} {{ pubkey_content[1] }}"
     dest: "{{ git_allowed_signers_file }}"
     mode: 0644
+  tags: git

--- a/playbooks/tasks/dotfiles/github.yml
+++ b/playbooks/tasks/dotfiles/github.yml
@@ -18,7 +18,7 @@
 
 - name: Clone all personal repositories
   when: clone_personal_repos
-  tags: github_repos
+  tags: github
   block:
     - name: Query GitHub API for my repositories
       ansible.builtin.uri:
@@ -61,7 +61,7 @@
 
 - name: Only clone notes repository
   when: not clone_personal_repos
-  tags: [github_repos, notes]
+  tags: github
   block:
     - name: Clone notes repo
       vars:
@@ -93,11 +93,11 @@
   loop: "{{ git_reference_repos }}"
   loop_control:
     label: "{{ item['repo'] }}"
-  tags: [github_repos, git_ref_repos]
+  tags: github
 
 - name: Symlink notes file
   ansible.builtin.file:
     src: "{{ ansible_user_dir }}/Development/Projects/notes-etc/main/README.md"
     dest: "{{ ansible_user_dir }}/Development/Reference/Notes.md"
     state: link
-  tags: core
+  tags: github

--- a/playbooks/tasks/dotfiles/k8s.yml
+++ b/playbooks/tasks/dotfiles/k8s.yml
@@ -6,11 +6,11 @@
   register: cmd_result
   changed_when: "'Installed plugin' in cmd_result['stdout']"
   failed_when: "'does not exist in the plugin index' in cmd_result['stdout']"
-  tags: krew
+  tags: [k8s, krew]
 
 - name: Install k9s configs
   ansible.builtin.copy:
     src: apps/k9s
     dest: "{{ k9s_config_path }}/"
     mode: 0644
-  tags: k9s
+  tags: [k8s, k9s]

--- a/playbooks/tasks/dotfiles/mac_apps.yml
+++ b/playbooks/tasks/dotfiles/mac_apps.yml
@@ -39,3 +39,28 @@
   loop_control:
     label: "{{ app }}"
   tags: icons
+
+- name: Check if Logi Options+ is installed
+  ansible.builtin.stat:
+    path: /Applications/logioptionsplus.app
+  register: logioptionsplus_app
+  tags: logi
+
+- name: Find Logi installer
+  ansible.builtin.find:
+    paths: "{{ homebrew_prefix }}/Caskroom/logi-options-plus"
+    follow: true
+    recurse: true
+    patterns: "logioptionsplus_installer.app"
+    file_type: directory
+  register: logioptionsplus_installer
+  when: not logioptionsplus_app.stat.exists
+  tags: logi
+
+- name: Copy Logi installer
+  ansible.builtin.copy:
+    src: "{{ logioptionsplus_installer['files'][0]['path'] }}"
+    dest: "{{ ansible_user_dir }}/Downloads"
+    mode: 0755
+  when: not logioptionsplus_app.stat.exists
+  tags: logi

--- a/playbooks/tasks/dotfiles/ssh.yml
+++ b/playbooks/tasks/dotfiles/ssh.yml
@@ -5,6 +5,7 @@
     path: "{{ ansible_user_dir }}/.ssh/authorized_keys"
     state: touch
     mode: 0600
+  tags: ssh
 
 - name: Create SSH key
   community.crypto.openssh_keypair:
@@ -16,9 +17,11 @@
   loop: "{{ ssh_keys | dict2items }}"
   loop_control:
     label: "{{ item['key'] }}"
+  tags: ssh
 
 - name: Install SSH configs
   ansible.builtin.copy:
     src: "ssh/{{ 'work' if work_system else 'home' }}.config"
     dest: "{{ ansible_user_dir }}/.ssh/config"
     mode: 0644
+  tags: ssh

--- a/playbooks/tasks/dotfiles/tmux.yml
+++ b/playbooks/tasks/dotfiles/tmux.yml
@@ -9,12 +9,14 @@
     - tmux
     - minimal
     - vscode
+  tags: tmux
 
 - name: Check for battery
   ansible.builtin.stat:
     path: /sys/class/power_supply/BAT0
   register: battery
   when: "'Linux' in ansible_system"
+  tags: tmux
 
 - name: Install tmux script
   vars:
@@ -23,3 +25,4 @@
     src: tmux-status.bash.j2
     dest: "{{ ansible_user_dir }}/.local/bin/tmux-status"
     mode: 0755
+  tags: tmux

--- a/playbooks/tasks/dotfiles/vim.yml
+++ b/playbooks/tasks/dotfiles/vim.yml
@@ -8,13 +8,15 @@
     backup: true
   register: _backup_vimrc
   notify: Process backups
+  tags: vim
 
 - name: Install vim extensions
   ansible.builtin.git:
     repo: "{{ item['repo'] }}"
     dest: "{{ ansible_user_dir }}/.vim/pack/default/start/{{ item['name'] }}"
-    depth: '1'
+    depth: "1"
     version: "{{ item['version'] | default(omit) }}"
   loop: "{{ vim_extensions }}"
   loop_control:
     label: "{{ item['name'] }}"
+  tags: vim

--- a/playbooks/tasks/dotfiles/zsh.yml
+++ b/playbooks/tasks/dotfiles/zsh.yml
@@ -9,6 +9,7 @@
   loop: "{{ zsh_plugins }}"
   loop_control:
     label: "{{ item['name'] }}"
+  tags: zsh
 
 - name: Generate Zsh completions
   environment:
@@ -18,7 +19,7 @@
   loop: "{{ zsh_completions }}"
   loop_control:
     label: "{{ item['name'] }}"
-  tags: [kubectl, stern, k9s]
+  tags: [zsh, kubectl, stern, k9s]
 
 - name: Get zsh version
   environment:
@@ -27,11 +28,13 @@
   changed_when: false
   when: "'Darwin' in ansible_system"
   register: zsh_version
+  tags: zsh
 
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto
   when: "'Linux' in ansible_system"
+  tags: zsh
 
 - name: Find Homebrew gnubin directories
   ansible.builtin.find:
@@ -43,6 +46,7 @@
     follow: true
   when: "'Darwin' in ansible_system"
   register: homebrew_gnubin
+  tags: zsh
 
 - name: Find Homebrew gnuman directories
   ansible.builtin.find:
@@ -54,6 +58,7 @@
     follow: true
   when: "'Darwin' in ansible_system"
   register: homebrew_gnuman
+  tags: zsh
 
 - name: Apply zshrc template
   vars:
@@ -65,8 +70,10 @@
     backup: true
   register: _backup_zshrc
   notify: Process backups
+  tags: zsh
 
 - name: Refresh zcompdump
+  tags: zsh
   block:
     - name: Delete zcompdump
       ansible.builtin.file:


### PR DESCRIPTION
* Moves Homebrew `logioptionsplus_installer.app` into `~/Downloads` if not installed (addresses #67)
* Added tagging to all imported tasks